### PR TITLE
Add Profile - Personal Details page and fix null warnings.

### DIFF
--- a/OrangeHRMTests/Constants/MenuFields.cs
+++ b/OrangeHRMTests/Constants/MenuFields.cs
@@ -1,0 +1,11 @@
+﻿namespace OrangeHRMTests.Constants
+{
+    internal static class MenuFields
+    {
+        public const string Admin = "Admin";
+        public const string PIM = "PIM";
+        public const string Leave = "Leave";
+        public const string MyInfo = "MyInfo";
+        public const string Dashboard = "Dashboard";
+    }
+}

--- a/OrangeHRMTests/Constants/PDFields.cs
+++ b/OrangeHRMTests/Constants/PDFields.cs
@@ -7,7 +7,7 @@
         public const string LastName = "LastName";
         public const string EmployeeId = "EmployeeId";
         public const string OtherId = "OtherId";
-        public const string DriversNumber = "DriverLicenseNumber";
+        public const string DriverLicenseNumber = "DriverLicenseNumber";
         public const string LicenseExpiryDate = "LicenseExpiryDate";
         public const string Nationality = "Nationality";
         public const string MaritalStatus = "MaritalStatus";

--- a/OrangeHRMTests/Constants/PDFields.cs
+++ b/OrangeHRMTests/Constants/PDFields.cs
@@ -1,0 +1,19 @@
+﻿namespace OrangeHRMTests.Constants
+{
+    internal static class PDFields
+    {
+        public const string FirstName = "FirstName";
+        public const string MiddleName = "MiddleName";
+        public const string LastName = "LastName";
+        public const string EmployeeId = "EmployeeId";
+        public const string OtherId = "OtherId";
+        public const string DriversNumber = "DriverLicenseNumber";
+        public const string LicenseExpiryDate = "LicenseExpiryDate";
+        public const string Nationality = "Nationality";
+        public const string MaritalStatus = "MaritalStatus";
+        public const string DateOfBirth = "DateOfBirth";
+        public const string MaleRadio = "MaleRadio";
+        public const string FemaleRadio = "FemaleRadio";
+        public const string SaveButton = "SaveButton";
+    }
+}

--- a/OrangeHRMTests/Constants/ProfileTabs.cs
+++ b/OrangeHRMTests/Constants/ProfileTabs.cs
@@ -1,0 +1,9 @@
+﻿namespace OrangeHRMTests.Constants
+{
+    internal static class ProfileTabs
+    {
+        public const string PersonalDetails = "PersonalDetails";
+        public const string ContactDetails = "ContactDetails";
+        public const string EmergencyContacts = "EmergencyContacts";
+    }
+}

--- a/OrangeHRMTests/Constants/TestAccount.cs
+++ b/OrangeHRMTests/Constants/TestAccount.cs
@@ -1,0 +1,8 @@
+﻿namespace OrangeHRMTests.Constants
+{
+    internal static class TestAccount
+    {
+        public const string Username = "Admin";
+        public const string Password = "admin123";
+    }
+}

--- a/OrangeHRMTests/Models/Profile/ProfilePDModel.cs
+++ b/OrangeHRMTests/Models/Profile/ProfilePDModel.cs
@@ -1,0 +1,94 @@
+﻿using System.Text.Json.Serialization;
+
+namespace OrangeHRMTests.Models.Profile
+{
+    internal class ProfilePDModel
+    {
+        [JsonPropertyName("name")]
+        public string Name { get; set; } = null!;
+
+        [JsonPropertyName("description")]
+        public string Description { get; set; } = null!;
+
+        [JsonPropertyName("testCases")]
+        public List<PDCase>? PDCases { get; set; }
+    }
+    internal class PDCase
+    {
+        [JsonPropertyName("testCaseId")]
+        public string TestCaseId { get; set; } = null!;
+
+        [JsonPropertyName("testCaseDescription")]
+        public string TestCaseDescription { get; set; } = null!;
+
+        [JsonPropertyName("testType")]
+        public string TestType { get; set; } = null!;
+
+        [JsonPropertyName("testData")]
+        public PDData? PDData { get; set; }
+
+        [JsonPropertyName("expectedResult")]
+        public ExpectedResult? ExpectedResult { get; set; }
+
+        // Custom name for each test case.
+        public override string ToString()
+        {
+            return $"{TestCaseId} : {TestCaseDescription}";
+        }
+    }
+    internal class PDData
+    {
+        [JsonPropertyName("firstName")]
+        public string FirstName { get; set; } = null!;
+
+        [JsonPropertyName("middleName")]
+        public string MiddleName { get; set; } = null!;
+
+        [JsonPropertyName("lastName")]
+        public string LastName { get; set; } = null!;
+
+        [JsonPropertyName("employeeId")]
+        public string EmployeeId { get; set; } = null!;
+
+        [JsonPropertyName("otherId")]
+        public string OtherId { get; set; } = null!;
+
+        [JsonPropertyName("driverLicense")]
+        public string DriverLicense { get; set; } = null!;
+
+        [JsonPropertyName("nationality")]
+        public string Nationality { get; set; } = null!;
+
+        [JsonPropertyName("maritalStatus")]
+        public string MaritalStatus { get; set; } = null!;
+
+        [JsonPropertyName("licenseExpiry")]
+        public string LicenseExpiry { get; set; } = null!;
+
+        [JsonPropertyName("dateOfBirth")]
+        public string DateOfBirth { get; set; } = null!;
+
+        [JsonPropertyName("gender")]
+        public string Gender { get; set; } = null!;
+    }
+    internal class ExpectedResult
+    {
+        [JsonPropertyName("result")]
+        public string Result { get; set; } = null!;
+
+        [JsonPropertyName("message")]
+        public string Message { get; set; } = null!;
+
+        [JsonPropertyName("fieldErrors")]
+        public List<FieldError>? FieldErrors { get; set; }
+    }
+
+    internal class FieldError
+    {
+        [JsonPropertyName("field")]
+        public string Field { get; set; } = null!;
+
+        [JsonPropertyName("message")]
+        public string Message { get; set; } = null!;
+    }
+}

--- a/OrangeHRMTests/OrangeHRMTests.csproj
+++ b/OrangeHRMTests/OrangeHRMTests.csproj
@@ -71,7 +71,6 @@
 
   <ItemGroup>
     <Folder Include="Reports\" />
-    <Folder Include="Tests\UI\Profile\" />
   </ItemGroup>
 
 </Project>

--- a/OrangeHRMTests/OrangeHRMTests.csproj
+++ b/OrangeHRMTests/OrangeHRMTests.csproj
@@ -59,6 +59,7 @@
 
   <ItemGroup>
     <Folder Include="Reports\" />
+    <Folder Include="Tests\UI\Profile\" />
   </ItemGroup>
 
 </Project>

--- a/OrangeHRMTests/OrangeHRMTests.csproj
+++ b/OrangeHRMTests/OrangeHRMTests.csproj
@@ -13,6 +13,7 @@
     <None Remove="appsettings.json" />
     <None Remove="TestData\Login\login_valid.json" />
     <None Remove="TestData\Profile\profile_pd_invalid.json" />
+    <None Remove="TestData\Profile\profile_pd_missing.json" />
     <None Remove="TestData\Profile\profile_pd_valid.json" />
   </ItemGroup>
 
@@ -30,6 +31,9 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
     <Content Include="TestData\Profile\profile_pd_invalid.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="TestData\Profile\profile_pd_missing.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
     <Content Include="TestData\Profile\profile_pd_valid.json">

--- a/OrangeHRMTests/OrangeHRMTests.csproj
+++ b/OrangeHRMTests/OrangeHRMTests.csproj
@@ -12,6 +12,7 @@
   <ItemGroup>
     <None Remove="appsettings.json" />
     <None Remove="TestData\Login\login_valid.json" />
+    <None Remove="TestData\Profile\profile_pd_invalid.json" />
     <None Remove="TestData\Profile\profile_pd_valid.json" />
   </ItemGroup>
 
@@ -26,6 +27,9 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
     <Content Include="TestData\Login\login_valid.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="TestData\Profile\profile_pd_invalid.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
     <Content Include="TestData\Profile\profile_pd_valid.json">

--- a/OrangeHRMTests/OrangeHRMTests.csproj
+++ b/OrangeHRMTests/OrangeHRMTests.csproj
@@ -12,6 +12,7 @@
   <ItemGroup>
     <None Remove="appsettings.json" />
     <None Remove="TestData\Login\login_valid.json" />
+    <None Remove="TestData\Profile\profile_pd_valid.json" />
   </ItemGroup>
 
   <ItemGroup>
@@ -25,6 +26,9 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
     <Content Include="TestData\Login\login_valid.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="TestData\Profile\profile_pd_valid.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
   </ItemGroup>

--- a/OrangeHRMTests/Pages/BasePage.cs
+++ b/OrangeHRMTests/Pages/BasePage.cs
@@ -4,7 +4,7 @@ using TestUtilities;
 
 namespace OrangeHRMTests.Pages
 {
-    internal class BasePage
+    internal abstract class BasePage
     {
         protected IWebDriver _driver;
 

--- a/OrangeHRMTests/Pages/Menu/NavigationMenuPage.cs
+++ b/OrangeHRMTests/Pages/Menu/NavigationMenuPage.cs
@@ -1,10 +1,23 @@
 ﻿using OpenQA.Selenium;
+using OrangeHRMTests.Constants;
 
 namespace OrangeHRMTests.Pages.Menu
 {
     internal class NavigationMenuPage : BasePage
     {
-        public NavigationMenuPage(IWebDriver driver) : base(driver) { }
+        // Dictionary for all elements.
+        private readonly Dictionary<string, By> _elements;
+        public NavigationMenuPage(IWebDriver driver) : base(driver)
+        {
+            _elements = new Dictionary<string, By>
+            {
+                { MenuFields.Admin, AdminMenuItem },
+                { MenuFields.PIM, PIMMenuItem },
+                { MenuFields.Leave, LeaveMenuItem },
+                { MenuFields.MyInfo, MyInfoMenuItem },
+                { MenuFields.Dashboard, DashboardMenuItem }
+            };
+        }
 
         private By AdminMenuItem = By.CssSelector("ul.oxd-main-menu a.oxd-main-menu-item[href=\'/web/index.php/admin/viewAdminModule\']");
         private By PIMMenuItem = By.CssSelector("ul.oxd-main-menu a.oxd-main-menu-item[href=\'/web/index.php/pim/viewPimModule\']");
@@ -12,11 +25,7 @@ namespace OrangeHRMTests.Pages.Menu
         private By MyInfoMenuItem = By.CssSelector("ul.oxd-main-menu a.oxd-main-menu-item[href=\'/web/index.php/pim/viewMyDetails\']");
         private By DashboardMenuItem = By.CssSelector("ul.oxd-main-menu a.oxd-main-menu-item[href=\'/web/index.php/dashboard/index\']");
 
-        public void ClickAdmin() => Click(AdminMenuItem);
-        public void ClickPIM() => Click(PIMMenuItem);
-        public void ClickLeave() => Click(LeaveMenuItem);
-        public void ClickInfo() => Click(MyInfoMenuItem);
-        public void ClickDashboard() => Click(DashboardMenuItem);
+        public void ClickElement(string fieldName) => Click(_elements[fieldName]);
 
     }
 }

--- a/OrangeHRMTests/Pages/Profile/ProfileCDPage.cs
+++ b/OrangeHRMTests/Pages/Profile/ProfileCDPage.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace OrangeHRMTests.Pages.Profile
+{
+    internal class ProfileCDPage
+    {
+    }
+}

--- a/OrangeHRMTests/Pages/Profile/ProfilePDPage.cs
+++ b/OrangeHRMTests/Pages/Profile/ProfilePDPage.cs
@@ -7,6 +7,7 @@ namespace OrangeHRMTests.Pages.Profile
     internal class ProfilePDPage : BasePage
     {
         public NavigationMenuPage _menu { get; }
+        public ProfileTabsPage _profileTab { get; }
 
         // Dictionary for all elements.
         private readonly Dictionary<string, By> _elements;
@@ -14,6 +15,7 @@ namespace OrangeHRMTests.Pages.Profile
         public ProfilePDPage(IWebDriver driver) : base(driver)
         {
             _menu = new NavigationMenuPage(driver);
+            _profileTab = new ProfileTabsPage(driver);
 
             _elements = new Dictionary<string, By>
             {

--- a/OrangeHRMTests/Pages/Profile/ProfilePDPage.cs
+++ b/OrangeHRMTests/Pages/Profile/ProfilePDPage.cs
@@ -1,6 +1,67 @@
-﻿namespace OrangeHRMTests.Pages.Profile
+﻿using OpenQA.Selenium;
+using OrangeHRMTests.Pages.Menu;
+
+namespace OrangeHRMTests.Pages.Profile
 {
-    internal class ProfilePDPage
+    internal class ProfilePDPage : BasePage
     {
+        public NavigationMenuPage _menu { get; }
+
+        // Dictionary
+        private readonly Dictionary<string, By> _elements;
+
+        public ProfilePDPage(IWebDriver driver) : base(driver)
+        {
+            _menu = new NavigationMenuPage(driver);
+
+            _elements = new Dictionary<string, By>
+            {
+                {"FirstName", FldFirstName},
+                {"MiddleName", FldMiddleName},
+                {"LastName", FldLastName},
+                {"EmployeeId", FldEmployeeId},
+                {"OtherId", FldOtherId},
+                {"DriverLicenseNumber", FldDriversNumber},
+                {"LicenseExpiry", DateLED},
+                {"Nationality", DrpdwnNationality},
+                {"MaritalStatus", DrpdwnMarital},
+                {"DateOfBirth", DateDOB},
+                {"MaleRadio", RadioMale},
+                {"FemaleRadio", RadioFemale},
+                {"SaveButton", BtnSave},
+            };
+        }
+
+        private By FldFirstName = By.Name("firstName");
+        private By FldMiddleName = By.Name("middleName");
+        private By FldLastName = By.Name("lastName");
+        private By FldEmployeeId = By.XPath("//label[text()='Employee Id']/following::input[1]");
+        private By FldOtherId = By.XPath("//label[text()='Other Id']/following::input[1]");
+        private By FldDriversNumber = By.XPath("//label[text()='Driver's License Number']/following::input[1]");
+        private By DateLED = By.XPath("//label[text()='License Expiry Date']/following::input[1]");
+        private By DrpdwnNationality = By.XPath("//label[text()='Nationality']/following::input[1]");
+        private By DrpdwnMarital = By.XPath("//label[text()='Marital Status']/following::input[1]");
+        private By DateDOB = By.XPath("//label[text()='Date of Birth']/following::input[1]");
+        private By RadioMale = By.XPath("//label[normalize-space()='Male']");
+        private By RadioFemale = By.XPath("//label[normalize-space()='Female']");
+        private By BtnSave = By.XPath("//button[text()='Save']");
+
+        // Checking if element is displayed
+        public bool IsDisplayed(string fieldName)
+        {
+            if (!_elements.ContainsKey(fieldName))
+                throw new ArgumentException($"Field '{fieldName}' not found in dictionary.");
+
+            return IsElementDisplayed(_elements[fieldName]);
+        }
+
+        // Enter text in input fields.
+        public void InputText(string fieldName, string value) => EnterText(_elements[fieldName], value);
+
+        // Select from dropdown.
+        public void SelectDropdownByText(string fieldName, string option) => SelectByText(_elements[fieldName], option);
+
+        // Click elements.
+        public void ClickElement(string fieldName) => Click(_elements[fieldName]);
     }
 }

--- a/OrangeHRMTests/Pages/Profile/ProfilePDPage.cs
+++ b/OrangeHRMTests/Pages/Profile/ProfilePDPage.cs
@@ -1,0 +1,6 @@
+﻿namespace OrangeHRMTests.Pages.Profile
+{
+    internal class ProfilePDPage
+    {
+    }
+}

--- a/OrangeHRMTests/Pages/Profile/ProfilePDPage.cs
+++ b/OrangeHRMTests/Pages/Profile/ProfilePDPage.cs
@@ -1,4 +1,5 @@
 ﻿using OpenQA.Selenium;
+using OrangeHRMTests.Constants;
 using OrangeHRMTests.Pages.Menu;
 
 namespace OrangeHRMTests.Pages.Profile
@@ -7,7 +8,7 @@ namespace OrangeHRMTests.Pages.Profile
     {
         public NavigationMenuPage _menu { get; }
 
-        // Dictionary
+        // Dictionary for all elements.
         private readonly Dictionary<string, By> _elements;
 
         public ProfilePDPage(IWebDriver driver) : base(driver)
@@ -16,19 +17,19 @@ namespace OrangeHRMTests.Pages.Profile
 
             _elements = new Dictionary<string, By>
             {
-                {"FirstName", FldFirstName},
-                {"MiddleName", FldMiddleName},
-                {"LastName", FldLastName},
-                {"EmployeeId", FldEmployeeId},
-                {"OtherId", FldOtherId},
-                {"DriverLicenseNumber", FldDriversNumber},
-                {"LicenseExpiry", DateLED},
-                {"Nationality", DrpdwnNationality},
-                {"MaritalStatus", DrpdwnMarital},
-                {"DateOfBirth", DateDOB},
-                {"MaleRadio", RadioMale},
-                {"FemaleRadio", RadioFemale},
-                {"SaveButton", BtnSave},
+                {PDFields.FirstName, FldFirstName},
+                {PDFields.MiddleName, FldMiddleName},
+                {PDFields.LastName, FldLastName},
+                {PDFields.EmployeeId, FldEmployeeId},
+                {PDFields.OtherId, FldOtherId},
+                {PDFields.DriverLicenseNumber, FldDriversNumber},
+                {PDFields.LicenseExpiryDate, DateLED},
+                {PDFields.Nationality, DrpdwnNationality},
+                {PDFields.MaritalStatus, DrpdwnMarital},
+                {PDFields.DateOfBirth, DateDOB},
+                {PDFields.MaleRadio, RadioMale},
+                {PDFields.FemaleRadio, RadioFemale},
+                {PDFields.SaveButton, BtnSave},
             };
         }
 

--- a/OrangeHRMTests/Pages/Profile/ProfileTabsPage.cs
+++ b/OrangeHRMTests/Pages/Profile/ProfileTabsPage.cs
@@ -1,0 +1,37 @@
+﻿using OpenQA.Selenium;
+using OrangeHRMTests.Constants;
+
+namespace OrangeHRMTests.Pages.Profile
+{
+    internal class ProfileTabsPage : BasePage
+    {
+        // Dictionary for all elements.
+        private readonly Dictionary<string, By> _elements;
+
+        public ProfileTabsPage(IWebDriver driver) : base(driver)
+        {
+            _elements = new Dictionary<string, By>
+            {
+                { ProfileTabs.PersonalDetails, PersonalDetailsTab },
+                { ProfileTabs.ContactDetails, ContactDetailsTab },
+                { ProfileTabs.EmergencyContacts, EmergencyContactsTab }
+            };
+        }
+
+        private By PersonalDetailsTab = By.LinkText("Personal Details");
+        private By ContactDetailsTab = By.LinkText("Contact Details");
+        private By EmergencyContactsTab = By.LinkText("Emergency Contacts");
+
+        // Checking if element is displayed.
+        public bool IsDisplayed(string fieldName)
+        {
+            if (!_elements.ContainsKey(fieldName))
+                throw new ArgumentException($"Field '{fieldName}' not found in dictionary.");
+
+            return IsElementDisplayed(_elements[fieldName]);
+        }
+
+        // Clicking an element.
+        public void ClickElement(string fieldName) => Click(_elements[fieldName]);
+    }
+}

--- a/OrangeHRMTests/TestData/Profile/profile_pd_invalid.json
+++ b/OrangeHRMTests/TestData/Profile/profile_pd_invalid.json
@@ -21,7 +21,13 @@
             },
             "expectedResult": {
                 "result": "The system prevents saving invalid data and an error message is displayed.",
-                "message": "Invalid date on license expiry field."
+                "message": "Invalid date on license expiry field.",
+                "fieldErrors": [
+                    {
+                        "field": "licenseExpiry",
+                        "message": "Should be a valid date in yyyy-dd-mm format"
+                    }
+                ]
             }
         },
         {
@@ -43,7 +49,13 @@
             },
             "expectedResult": {
                 "result": "The system prevents saving invalid data and an error message is displayed.",
-                "message": "Invalid date on date of birth field."
+                "message": "Invalid date on date of birth field.",
+                "fieldErrors": [
+                    {
+                        "field": "dateOfBirth",
+                        "message": "Should be a valid date in yyyy-dd-mm format"
+                    }
+                ]
             }
         },
         {
@@ -65,7 +77,17 @@
             },
             "expectedResult": {
                 "result": "The system prevents saving invalid data and an error message is displayed.",
-                "message": "Invalid date on license expiry and date of birth fields."
+                "message": "Invalid date on license expiry and date of birth fields.",
+                "fieldErrors": [
+                    {
+                        "field": "licenseExpiry",
+                        "message": "Should be a valid date in yyyy-dd-mm format"
+                    },
+                    {
+                        "field": "dateOfBirth",
+                        "message": "Should be a valid date in yyyy-dd-mm format"
+                    }
+                ]
             }
         }
     ]

--- a/OrangeHRMTests/TestData/Profile/profile_pd_invalid.json
+++ b/OrangeHRMTests/TestData/Profile/profile_pd_invalid.json
@@ -1,0 +1,72 @@
+{
+    "name": "Profile Test Data",
+    "description": "Test data(s) for negative profile - personal details scenarios.",
+    "testCases": [
+        {
+            "testCaseId": "TC_Profile_0014_1",
+            "testCaseDescription": "Verify that data saving fails in the ‘Personal Details’ tab when invalid inputs are provided.",
+            "testType": "Negative",
+            "testData": {
+                "firstName": "Johnny",
+                "middleName": "Apple",
+                "lastName": "Seed",
+                "employeeId": "123456",
+                "otherId": "789012",
+                "driverLicense": "DRV1122333",
+                "nationality": "American",
+                "maritalStatus": "Single",
+                "licenseExpiry": "LicenseDate",
+                "dateOfBirth": "1995-01-08",
+                "gender": "Male"
+            },
+            "expectedResult": {
+                "result": "The system prevents saving invalid data and an error message is displayed.",
+                "message": "Invalid date on license expiry field."
+            }
+        },
+        {
+            "testCaseId": "TC_Profile_0014_2",
+            "testCaseDescription": "Verify that data saving fails in the ‘Personal Details’ tab when invalid inputs are provided.",
+            "testType": "Negative",
+            "testData": {
+                "firstName": "Johnny",
+                "middleName": "Apple",
+                "lastName": "Seed",
+                "employeeId": "123456",
+                "otherId": "789012",
+                "driverLicense": "DRV1122333",
+                "nationality": "American",
+                "maritalStatus": "Single",
+                "licenseExpiry": "2030-01-10",
+                "dateOfBirth": "DateOfBirth",
+                "gender": "Male"
+            },
+            "expectedResult": {
+                "result": "The system prevents saving invalid data and an error message is displayed.",
+                "message": "Invalid date on date of birth field."
+            }
+        },
+        {
+            "testCaseId": "TC_Profile_0014_3",
+            "testCaseDescription": "Verify that data saving fails in the ‘Personal Details’ tab when invalid inputs are provided.",
+            "testType": "Negative",
+            "testData": {
+                "firstName": "Johnny",
+                "middleName": "Apple",
+                "lastName": "Seed",
+                "employeeId": "123456",
+                "otherId": "789012",
+                "driverLicense": "DRV1122333",
+                "nationality": "American",
+                "maritalStatus": "Single",
+                "licenseExpiry": "LicenseDate",
+                "dateOfBirth": "DateOfBirth",
+                "gender": "Male"
+            },
+            "expectedResult": {
+                "result": "The system prevents saving invalid data and an error message is displayed.",
+                "message": "Invalid date on license expiry and date of birth fields."
+            }
+        }
+    ]
+}

--- a/OrangeHRMTests/TestData/Profile/profile_pd_missing.json
+++ b/OrangeHRMTests/TestData/Profile/profile_pd_missing.json
@@ -21,7 +21,13 @@
             },
             "expectedResult": {
                 "result": "The system prevents saving invalid data and an error message is displayed.",
-                "message": "Missing first name."
+                "message": "Missing first name.",
+                "fieldErrors": [
+                    {
+                        "field": "firstName",
+                        "message": "Required"
+                    }
+                ]
             }
         },
         {
@@ -43,7 +49,13 @@
             },
             "expectedResult": {
                 "result": "The system prevents saving invalid data and an error message is displayed.",
-                "message": "Missing last name."
+                "message": "Missing last name.",
+                "fieldErrors": [
+                    {
+                        "field": "lastName",
+                        "message": "Required"
+                    }
+                ]
             }
         },
         {
@@ -65,7 +77,17 @@
             },
             "expectedResult": {
                 "result": "The system prevents saving invalid data and an error message is displayed.",
-                "message": "Missing first and last name."
+                "message": "Missing first and last name.",
+                "fieldErrors": [
+                    {
+                        "field": "firstName",
+                        "message": "Required"
+                    },
+                    {
+                        "field": "lastName",
+                        "message": "Required"
+                    }
+                ]
             }
         },
     ]

--- a/OrangeHRMTests/TestData/Profile/profile_pd_missing.json
+++ b/OrangeHRMTests/TestData/Profile/profile_pd_missing.json
@@ -1,0 +1,72 @@
+{
+    "name": "Profile Test Data",
+    "description": "Test data(s) for negative profile - personal details scenarios.",
+    "testCases": [
+        {
+            "testCaseId": "TC_Profile_0014_4",
+            "testCaseDescription": "Verify that data saving fails in the ‘Personal Details’ tab with missing first name.",
+            "testType": "Negative",
+            "testData": {
+                "firstName": "",
+                "middleName": "Apple",
+                "lastName": "Seed",
+                "employeeId": "123456",
+                "otherId": "789012",
+                "driverLicense": "DRV1122333",
+                "nationality": "American",
+                "maritalStatus": "Single",
+                "licenseExpiry": "LicenseDate",
+                "dateOfBirth": "1995-01-08",
+                "gender": "Male"
+            },
+            "expectedResult": {
+                "result": "The system prevents saving invalid data and an error message is displayed.",
+                "message": "Missing first name."
+            }
+        },
+        {
+            "testCaseId": "TC_Profile_0014_5",
+            "testCaseDescription": "Verify that data saving fails in the ‘Personal Details’ tab with missing last name.",
+            "testType": "Negative",
+            "testData": {
+                "firstName": "Johnny",
+                "middleName": "Apple",
+                "lastName": "",
+                "employeeId": "123456",
+                "otherId": "789012",
+                "driverLicense": "DRV1122333",
+                "nationality": "American",
+                "maritalStatus": "Single",
+                "licenseExpiry": "LicenseDate",
+                "dateOfBirth": "1995-01-08",
+                "gender": "Male"
+            },
+            "expectedResult": {
+                "result": "The system prevents saving invalid data and an error message is displayed.",
+                "message": "Missing last name."
+            }
+        },
+        {
+            "testCaseId": "TC_Profile_0014_6",
+            "testCaseDescription": "Verify that data saving fails in the ‘Personal Details’ tab with missing first and last name.",
+            "testType": "Negative",
+            "testData": {
+                "firstName": "",
+                "middleName": "Apple",
+                "lastName": "",
+                "employeeId": "123456",
+                "otherId": "789012",
+                "driverLicense": "DRV1122333",
+                "nationality": "American",
+                "maritalStatus": "Single",
+                "licenseExpiry": "LicenseDate",
+                "dateOfBirth": "1995-01-08",
+                "gender": "Male"
+            },
+            "expectedResult": {
+                "result": "The system prevents saving invalid data and an error message is displayed.",
+                "message": "Missing first and last name."
+            }
+        },
+    ]
+}

--- a/OrangeHRMTests/TestData/Profile/profile_pd_valid.json
+++ b/OrangeHRMTests/TestData/Profile/profile_pd_valid.json
@@ -1,0 +1,28 @@
+{
+    "name": "Profile Test Data",
+    "description": "Test data(s) for positive profile - personal details scenarios.",
+    "testCases": [
+        {
+            "testCaseId": "TC_Profile_0013_1",
+            "testCaseDescription": "Verify that data entered in ‘Personal Details’ is saved successfully.",
+            "testType": "Positive",
+            "testData": {
+                "firstName": "Johnny",
+                "middleName": "Apple",
+                "lastName": "Seed",
+                "employeeId": "123456",
+                "otherId": "789012",
+                "driverLicense": "DRV1122333",
+                "nationality": "American",
+                "maritalStatus": "Single",
+                "licenseExpiry": "2030-01-10",
+                "dateOfBirth": "1995-01-08",
+                "gender": "Male"
+            },
+            "expectedResult": {
+                "result": "Data entered is saved.",
+                "message": "Data entered is saved."
+            }
+        }
+    ]
+}

--- a/OrangeHRMTests/Tests/BaseTest.cs
+++ b/OrangeHRMTests/Tests/BaseTest.cs
@@ -4,14 +4,14 @@ using TestUtilities;
 
 namespace OrangeHRMTests.Tests
 {
-    internal class BaseTest
+    internal abstract class BaseTest
     {
         protected AppConfig _config;
         [System.Diagnostics.CodeAnalysis.SuppressMessage(
             "Structure",
             "NUnit1032:An IDisposable field/property should be Disposed in a TearDown method",
             Justification = "Dispose and Quit are handled by CloseDriver method.")]
-        protected IWebDriver _driver;
+        protected IWebDriver? _driver;
 
         [OneTimeSetUp]
         public void ReportSetup() => ReportManager.CreateExtentReport("OrangeHRM");
@@ -35,10 +35,10 @@ namespace OrangeHRMTests.Tests
 
             TestResultHelper.LogTestResults(
                 testStatus,
-                _driver,
+                _driver!,
                 testMessage,
-                stackTrace,
-                testMethodName);
+                stackTrace!,
+                testMethodName!);
 
             if (_driver != null)
             {

--- a/OrangeHRMTests/Tests/UI/Login/LoginTests.cs
+++ b/OrangeHRMTests/Tests/UI/Login/LoginTests.cs
@@ -13,7 +13,7 @@ namespace OrangeHRMTests.Tests.UI.Login
         public override void Setup()
         {
             base.Setup();
-            _login = new LoginPage(_driver);
+            _login = new LoginPage(_driver!);
             ReportManager.LogInfo("Navigating to OrangeHRM demo website.");
             _login.NavigateToUrl(_config.BaseUrl);
         }
@@ -64,7 +64,7 @@ namespace OrangeHRMTests.Tests.UI.Login
             _login.EnterPassword(testCase.TestData!.Password);
             ReportManager.LogInfo("Clicking login button.");
             _login.ClickLoginButton();
-            if (testCase.ExpectedResult.FieldErrors != null && testCase.ExpectedResult.FieldErrors.Any())
+            if (testCase.ExpectedResult!.FieldErrors != null && testCase.ExpectedResult.FieldErrors.Any())
             {
                 // To loop on all fields.
                 foreach (var expected in testCase.ExpectedResult.FieldErrors)
@@ -90,7 +90,7 @@ namespace OrangeHRMTests.Tests.UI.Login
             ReportManager.LogInfo("Clicking logout button.");
             _login._topbar.ClickLogoutButton();
             ReportManager.LogInfo("Verifying that user is redirected to login page");
-            Assert.That(_driver.Url.Contains("login"), Is.True);
+            Assert.That(_driver!.Url.Contains("login"), Is.True);
         }
     }
 }

--- a/OrangeHRMTests/Tests/UI/Profile/ProfilePersonalDetailsTests.cs
+++ b/OrangeHRMTests/Tests/UI/Profile/ProfilePersonalDetailsTests.cs
@@ -1,0 +1,29 @@
+﻿using OrangeHRMTests.Constants;
+using OrangeHRMTests.Pages.Profile;
+using OrangeHRMTests.Utils;
+using TestUtilities;
+
+namespace OrangeHRMTests.Tests.UI.Profile
+{
+    internal class ProfilePersonalDetailsTests : BaseTest
+    {
+        private ProfilePDPage _profilePD;
+
+        [SetUp]
+        public override void Setup()
+        {
+            base.Setup();
+            _profilePD = new ProfilePDPage(_driver!);
+
+            ReportManager.LogInfo("Navigating and logging in to OrangeHRM demo website.");
+            TestFlow.LoginAsAdmin(_driver!, _config.BaseUrl);
+        }
+
+        [Test]
+        public void Profile_VerifyPersonalDetailsIsAccessible()
+        {
+            ReportManager.LogInfo("Navigating to MyInfo page");
+            _profilePD._menu.ClickElement(MenuFields.MyInfo);
+        }
+    }
+}

--- a/OrangeHRMTests/Tests/UI/Profile/ProfilePersonalDetailsTests.cs
+++ b/OrangeHRMTests/Tests/UI/Profile/ProfilePersonalDetailsTests.cs
@@ -22,8 +22,12 @@ namespace OrangeHRMTests.Tests.UI.Profile
         [Test]
         public void Profile_VerifyPersonalDetailsIsAccessible()
         {
-            ReportManager.LogInfo("Navigating to MyInfo page");
+            ReportManager.LogInfo("Navigating to MyInfo page.");
             _profilePD._menu.ClickElement(MenuFields.MyInfo);
+            ReportManager.LogInfo("Navigating to 'Personal Details' tab.");
+            _profilePD._profileTab.ClickElement(ProfileTabs.PersonalDetails);
+            ReportManager.LogInfo("Verify that 'Personal Details' tab loads successfully.");
+            Assert.That(_profilePD._profileTab.IsDisplayed(ProfileTabs.PersonalDetails), Is.True);
         }
     }
 }

--- a/OrangeHRMTests/Utils/Providers/ProfileProvider.cs
+++ b/OrangeHRMTests/Utils/Providers/ProfileProvider.cs
@@ -28,9 +28,9 @@ namespace OrangeHRMTests.Utils.Providers
         }
 
         // Get single record
-        public static PDCase GetValidCaseRecord(string id) => GetRecordById(id, PDValid);
-        public static PDCase GetInvalidCaseRecord(string id) => GetRecordById(id, PDInvalid);
-        public static PDCase GetMissingCaseRecord(string id) => GetRecordById(id, PDMissing);
+        public static PDCase GetValidPDCaseRecord(string id) => GetRecordById(id, PDValid);
+        public static PDCase GetInvalidPDCaseRecord(string id) => GetRecordById(id, PDInvalid);
+        public static PDCase GetMissingPDCaseRecord(string id) => GetRecordById(id, PDMissing);
 
         // Get multiple records
         public static IEnumerable<PDCase> GetValidPDCaseRecords() => GetRecords(PDValid);

--- a/OrangeHRMTests/Utils/Providers/ProfileProvider.cs
+++ b/OrangeHRMTests/Utils/Providers/ProfileProvider.cs
@@ -1,0 +1,40 @@
+﻿using OrangeHRMTests.Models.Profile;
+using TestUtilities;
+
+namespace OrangeHRMTests.Utils.Providers
+{
+    internal class ProfileProvider
+    {
+        // Always return the case level.
+        private const string folderName = "TestData";
+        private const string moduleName = "Profile";
+        private const string PDValid = "profile_pd_valid.json";
+        private const string PDInvalid = "profile_pd_invalid.json";
+        private const string PDMissing = "profile_pd_missing.json";
+
+
+        // PD model:
+        public static PDCase GetRecordById(string id, string fileName)
+        {
+            var data = TestDataLoader.Load<ProfilePDModel>(folderName, moduleName, fileName);
+            var record = data?.PDCases?.FirstOrDefault(tc => tc.TestCaseId == id);
+            return record!;
+        }
+
+        public static IEnumerable<PDCase> GetRecords(string fileName)
+        {
+            var data = TestDataLoader.Load<ProfilePDModel>(folderName, moduleName, fileName);
+            return data?.PDCases ?? Enumerable.Empty<PDCase>();
+        }
+
+        // Get single record
+        public static PDCase GetValidCaseRecord(string id) => GetRecordById(id, PDValid);
+        public static PDCase GetInvalidCaseRecord(string id) => GetRecordById(id, PDInvalid);
+        public static PDCase GetMissingCaseRecord(string id) => GetRecordById(id, PDMissing);
+
+        // Get multiple records
+        public static IEnumerable<PDCase> GetValidPDCaseRecords() => GetRecords(PDValid);
+        public static IEnumerable<PDCase> GetInvalidPDCaseRecords() => GetRecords(PDInvalid);
+        public static IEnumerable<PDCase> GetMissingPDCaseRecords() => GetRecords(PDMissing);
+    }
+}

--- a/OrangeHRMTests/Utils/TestFlow.cs
+++ b/OrangeHRMTests/Utils/TestFlow.cs
@@ -1,18 +1,32 @@
 ﻿using OpenQA.Selenium;
+using OrangeHRMTests.Constants;
 using OrangeHRMTests.Pages.Login;
+using OrangeHRMTests.Pages.Menu;
 
 namespace OrangeHRMTests.Utils
 {
     internal class TestFlow
     {
-        public static void LoginAsAdmin(IWebDriver driver, string username, string password, string url)
+        public static void LoginAsAdmin(IWebDriver driver, string url)
         {
             var login = new LoginPage(driver);
 
             login.NavigateToUrl(url);
-            login.EnterUsername(username);
-            login.EnterPassword(password);
+            login.EnterUsername(TestAccount.Username);
+            login.EnterPassword(TestAccount.Password);
             login.ClickLoginButton();
+        }
+
+        public void NavigateToMyInfo(IWebDriver driver, string url)
+        {
+            var login = new LoginPage(driver);
+            var menu = new NavigationMenuPage(driver);
+
+            login.NavigateToUrl(url);
+            login.EnterUsername(TestAccount.Username);
+            login.EnterPassword(TestAccount.Password);
+            login.ClickLoginButton();
+            menu.ClickElement(MenuFields.MyInfo);
         }
     }
 }

--- a/SauceDemoTests/Tests/BaseTest.cs
+++ b/SauceDemoTests/Tests/BaseTest.cs
@@ -4,13 +4,13 @@ using TestUtilities;
 
 namespace SauceDemoTests.Tests
 {
-    public class BaseTest
+    public abstract class BaseTest
     {
         [System.Diagnostics.CodeAnalysis.SuppressMessage(
             "Structure",
             "NUnit1032:An IDisposable field/property should be Disposed in a TearDown method",
             Justification = "Dispose and Quit are handled by CloseDriver method.")]
-        protected IWebDriver _driver;
+        protected IWebDriver? _driver;
         protected AppConfig _config;
 
         [OneTimeSetUp]
@@ -48,10 +48,10 @@ namespace SauceDemoTests.Tests
             // Needed for logging test results in report.
             TestResultHelper.LogTestResults(
                 testStatus,
-                _driver,
+                _driver!,
                 testMessage,
-                stackTrace,
-                testMethodName);
+                stackTrace!,
+                testMethodName!);
 
             // Close driver.
             if (_driver != null)

--- a/SauceDemoTests/Tests/E2E/CancelCheckoutFlow_E2ETests.cs
+++ b/SauceDemoTests/Tests/E2E/CancelCheckoutFlow_E2ETests.cs
@@ -24,7 +24,7 @@ namespace SauceDemoTests.Tests.E2E
 
             // Navigate to SauceDemo website.
             ReportManager.LogInfo("Navigating to SauceDemo website.");
-            _driver.Navigate().GoToUrl(_config.BaseUrl);
+            _driver!.Navigate().GoToUrl(_config.BaseUrl);
 
             // Initialize all POMs.
             _cart = new CartPage(_driver);
@@ -36,7 +36,7 @@ namespace SauceDemoTests.Tests.E2E
         }
 
         // For assertions that verify the url.
-        private void AssertUrlContains(string url) => Assert.That(_driver.Url.Contains(url), Is.True);
+        private void AssertUrlContains(string url) => Assert.That(_driver!.Url.Contains(url), Is.True);
 
         [Test]
         [TestCase(

--- a/SauceDemoTests/Tests/E2E/CartManagementFlow_E2ETests.cs
+++ b/SauceDemoTests/Tests/E2E/CartManagementFlow_E2ETests.cs
@@ -24,7 +24,7 @@ namespace SauceDemoTests.Tests.E2E
 
             // Navigate to SauceDemo website.
             ReportManager.LogInfo("Navigating to SauceDemo website.");
-            _driver.Navigate().GoToUrl(_config.BaseUrl);
+            _driver!.Navigate().GoToUrl(_config.BaseUrl);
 
             // Initialize all POMs.
             _cart = new CartPage(_driver);
@@ -36,7 +36,7 @@ namespace SauceDemoTests.Tests.E2E
         }
 
         // For assertions that verify the url.
-        private void AssertUrlContains(string url) => Assert.That(_driver.Url.Contains(url), Is.True);
+        private void AssertUrlContains(string url) => Assert.That(_driver!.Url.Contains(url), Is.True);
 
         [Test]
         [TestCase(

--- a/SauceDemoTests/Tests/E2E/FullPurchaseFlow_E2ETests.cs
+++ b/SauceDemoTests/Tests/E2E/FullPurchaseFlow_E2ETests.cs
@@ -24,7 +24,7 @@ namespace SauceDemoTests.Tests.E2E
 
             // Navigate to SauceDemo website.
             ReportManager.LogInfo("Navigating to SauceDemo website.");
-            _driver.Navigate().GoToUrl(_config.BaseUrl);
+            _driver!.Navigate().GoToUrl(_config.BaseUrl);
 
             // Initialize all POMs.
             _cart = new CartPage(_driver);
@@ -36,7 +36,7 @@ namespace SauceDemoTests.Tests.E2E
         }
 
         // For assertions that verify the url.
-        private void AssertUrlContains(string url) => Assert.That(_driver.Url.Contains(url), Is.True);
+        private void AssertUrlContains(string url) => Assert.That(_driver!.Url.Contains(url), Is.True);
 
         [Test]
         [TestCase(

--- a/SauceDemoTests/Tests/E2E/FullPurchaseFlow_GlitchUser_E2ETests.cs
+++ b/SauceDemoTests/Tests/E2E/FullPurchaseFlow_GlitchUser_E2ETests.cs
@@ -24,7 +24,7 @@ namespace SauceDemoTests.Tests.E2E
 
             // Navigate to SauceDemo website.
             ReportManager.LogInfo("Navigating to SauceDemo website.");
-            _driver.Navigate().GoToUrl(_config.BaseUrl);
+            _driver!.Navigate().GoToUrl(_config.BaseUrl);
 
             // Initialize all POMs.
             _cart = new CartPage(_driver);
@@ -36,7 +36,7 @@ namespace SauceDemoTests.Tests.E2E
         }
 
         // For assertions that verify the url.
-        private void AssertUrlContains(string url) => Assert.That(_driver.Url.Contains(url), Is.True);
+        private void AssertUrlContains(string url) => Assert.That(_driver!.Url.Contains(url), Is.True);
 
         [Test]
         [TestCase(

--- a/SauceDemoTests/Tests/E2E/FullPurchaseFlow_ProblemUser_E2ETests.cs
+++ b/SauceDemoTests/Tests/E2E/FullPurchaseFlow_ProblemUser_E2ETests.cs
@@ -24,7 +24,7 @@ namespace SauceDemoTests.Tests.E2E
 
             // Navigate to SauceDemo website.
             ReportManager.LogInfo("Navigating to SauceDemo website.");
-            _driver.Navigate().GoToUrl(_config.BaseUrl);
+            _driver!.Navigate().GoToUrl(_config.BaseUrl);
 
             // Initialize all POMs.
             _cart = new CartPage(_driver);
@@ -36,7 +36,7 @@ namespace SauceDemoTests.Tests.E2E
         }
 
         // For assertions that verify the url.
-        private void AssertUrlContains(string url) => Assert.That(_driver.Url.Contains(url), Is.True);
+        private void AssertUrlContains(string url) => Assert.That(_driver!.Url.Contains(url), Is.True);
 
         [Test]
         [TestCase(

--- a/SauceDemoTests/Tests/E2E/SessionLifecycleFlow_E2ETests.cs
+++ b/SauceDemoTests/Tests/E2E/SessionLifecycleFlow_E2ETests.cs
@@ -24,7 +24,7 @@ namespace SauceDemoTests.Tests.E2E
 
             // Navigate to SauceDemo website.
             ReportManager.LogInfo("Navigating to SauceDemo website.");
-            _driver.Navigate().GoToUrl(_config.BaseUrl);
+            _driver!.Navigate().GoToUrl(_config.BaseUrl);
 
             // Initialize all POMs.
             _cart = new CartPage(_driver);
@@ -36,7 +36,7 @@ namespace SauceDemoTests.Tests.E2E
         }
 
         // For assertions that verify the url.
-        private void AssertUrlContains(string url) => Assert.That(_driver.Url.Contains(url), Is.True);
+        private void AssertUrlContains(string url) => Assert.That(_driver!.Url.Contains(url), Is.True);
 
         [Test]
         [TestCase(
@@ -72,7 +72,7 @@ namespace SauceDemoTests.Tests.E2E
 
             // Go to cart page without logging in.
             ReportManager.LogInfo("Navigating to cart page of SauceDemo.");
-            _driver.Navigate().GoToUrl("https://www.saucedemo.com/v1/cart.html");
+            _driver!.Navigate().GoToUrl("https://www.saucedemo.com/v1/cart.html");
             // Known issue with SauceDem - User can still access other pages such as /cart or /inventory.
             ReportManager.LogInfo("SauceDemo issue: After logout, user can still access /cart.html via URL.");
             // Assert.That(_driver.Url.Contains("cart"), Is.False);

--- a/SauceDemoTests/Tests/UI/Cart/CartTests.cs
+++ b/SauceDemoTests/Tests/UI/Cart/CartTests.cs
@@ -17,12 +17,12 @@ namespace SauceDemoTests.Tests.UI.Cart
             base.SetUp();
 
             // Initialize CartPage, and ProductPage.
-            _product = new ProductPage(_driver);
-            _cart = new CartPage(_driver);
+            _product = new ProductPage(_driver!);
+            _cart = new CartPage(_driver!);
 
             // Navigate to SauceDemo Website.
             ReportManager.LogInfo("Navigating to SauceDemo website.");
-            _driver.Navigate().GoToUrl(_config.BaseUrl);
+            _driver!.Navigate().GoToUrl(_config.BaseUrl);
 
             // Log in to the website
             ReportManager.LogInfo("Log in as standard user.");
@@ -193,7 +193,7 @@ namespace SauceDemoTests.Tests.UI.Cart
             _cart.ClickContinueShoppingItem();
 
             ReportManager.LogInfo("Verifying that the user is redirected to product list page.");
-            Assert.That(_driver.Url.Contains("inventory"), Is.True);
+            Assert.That(_driver!.Url.Contains("inventory"), Is.True);
         }
 
         // No test case available.
@@ -210,7 +210,7 @@ namespace SauceDemoTests.Tests.UI.Cart
             _cart.ClickCheckoutCartItem();
 
             ReportManager.LogInfo("Verifying that the user is redirected to checkout step one page.");
-            Assert.That(_driver.Url.Contains("checkout-step-one"), Is.True);
+            Assert.That(_driver!.Url.Contains("checkout-step-one"), Is.True);
         }
     }
 }

--- a/SauceDemoTests/Tests/UI/Checkout/CheckoutStepOneTests.cs
+++ b/SauceDemoTests/Tests/UI/Checkout/CheckoutStepOneTests.cs
@@ -19,12 +19,12 @@ namespace SauceDemoTests.Tests.UI.Checkout
             base.SetUp();
 
             // Initialize CartPage and CheckoutStepOnePage.
-            _cart = new CartPage(_driver);
-            _stepOne = new CheckoutStepOnePage(_driver);
+            _cart = new CartPage(_driver!);
+            _stepOne = new CheckoutStepOnePage(_driver!);
 
             // Navigate to SauceDemo Website.
             ReportManager.LogInfo("Navigating to SauceDemo website.");
-            _driver.Navigate().GoToUrl(_config.BaseUrl);
+            _driver!.Navigate().GoToUrl(_config.BaseUrl);
 
             PreconditionFlow.FromLoginToCartFlow(_driver, "standard_user", "secret_sauce");
         }
@@ -35,7 +35,7 @@ namespace SauceDemoTests.Tests.UI.Checkout
         {
             ReportManager.LogInfo("Clicking 'Checkout' button.");
             _cart.ClickCheckoutCartItem();
-            Assert.That(_driver.Url.Contains("checkout-step-one"), Is.True);
+            Assert.That(_driver!.Url.Contains("checkout-step-one"), Is.True);
         }
 
         // TC_Checkout_0002
@@ -76,14 +76,14 @@ namespace SauceDemoTests.Tests.UI.Checkout
         {
             Checkout_StepOne_NavigateToCheckout();
             ReportManager.LogInfo("Entering user first name.");
-            _stepOne.ChkoutEnterFirstName(testCase.testData.firstName);
+            _stepOne.ChkoutEnterFirstName(testCase.testData!.firstName);
             ReportManager.LogInfo("Entering user last name.");
-            _stepOne.ChkoutEnterLastName(testCase.testData.lastName);
+            _stepOne.ChkoutEnterLastName(testCase.testData!.lastName);
             ReportManager.LogInfo("Entering user postal code.");
-            _stepOne.ChkoutPostalCode(testCase.testData.postalCode);
+            _stepOne.ChkoutPostalCode(testCase.testData!.postalCode);
             ReportManager.LogInfo("Clicking 'continue' button.");
             _stepOne.ClickContinueButton();
-            Assert.That(_driver.Url.Contains("checkout-step-two"), Is.True);
+            Assert.That(_driver!.Url.Contains("checkout-step-two"), Is.True);
         }
 
         // TC_Checkout_0006; TC_Checkout_0007; TC_Checkout_0008; TC_Checkout_0009; TC_Checkout_0010; TC_Checkout_0011
@@ -93,11 +93,11 @@ namespace SauceDemoTests.Tests.UI.Checkout
         {
             Checkout_StepOne_NavigateToCheckout();
             ReportManager.LogInfo("Entering user first name.");
-            _stepOne.ChkoutEnterFirstName(testCase.testData.firstName);
+            _stepOne.ChkoutEnterFirstName(testCase.testData!.firstName);
             ReportManager.LogInfo("Entering user last name.");
-            _stepOne.ChkoutEnterLastName(testCase.testData.lastName);
+            _stepOne.ChkoutEnterLastName(testCase.testData!.lastName);
             ReportManager.LogInfo("Entering user postal code.");
-            _stepOne.ChkoutPostalCode(testCase.testData.postalCode);
+            _stepOne.ChkoutPostalCode(testCase.testData!.postalCode);
             ReportManager.LogInfo("Clicking 'continue' button.");
             _stepOne.ClickContinueButton();
             Assert.That(_stepOne.IsErrorMessageDisplayed(), Is.True);

--- a/SauceDemoTests/Tests/UI/Checkout/CheckoutStepTwoTests.cs
+++ b/SauceDemoTests/Tests/UI/Checkout/CheckoutStepTwoTests.cs
@@ -19,13 +19,13 @@ namespace SauceDemoTests.Tests.UI.Checkout
             base.SetUp();
 
             // Initialize MenuBarPage, CheckoutStepOnePage, and CheckoutStepTwoPage.
-            _menu = new MenuBarPage(_driver);
-            _stepOne = new CheckoutStepOnePage(_driver);
-            _stepTwo = new CheckoutStepTwoPage(_driver);
+            _menu = new MenuBarPage(_driver!);
+            _stepOne = new CheckoutStepOnePage(_driver!);
+            _stepTwo = new CheckoutStepTwoPage(_driver!);
 
             // Navigate to SauceDemo Website.
             ReportManager.LogInfo("Navigating to SauceDemo website.");
-            _driver.Navigate().GoToUrl(_config.BaseUrl);
+            _driver!.Navigate().GoToUrl(_config.BaseUrl);
 
             PreconditionFlow.FromLoginToCheckoutFlow(_driver, "standard_user", "secret_sauce");
         }
@@ -41,7 +41,7 @@ namespace SauceDemoTests.Tests.UI.Checkout
             _stepOne.ChkoutPostalCode("1111");
             ReportManager.LogInfo("Clicking 'continue' button.");
             _stepOne.ClickContinueButton();
-            Assert.That(_driver.Url.Contains("checkout-step-two"), Is.True);
+            Assert.That(_driver!.Url.Contains("checkout-step-two"), Is.True);
         }
 
         // TC_Checkout_0013
@@ -115,7 +115,7 @@ namespace SauceDemoTests.Tests.UI.Checkout
             ReportManager.LogInfo("Clicking 'Finish' button.");
             _stepTwo.ClickFinishButton();
             ReportManager.LogInfo("Verifying that the user completes the order.");
-            Assert.That(_driver.Url.Contains("checkout-complete"), Is.True);
+            Assert.That(_driver!.Url.Contains("checkout-complete"), Is.True);
         }
 
         // TC_Checkout_0021

--- a/SauceDemoTests/Tests/UI/Login/LoginTests.cs
+++ b/SauceDemoTests/Tests/UI/Login/LoginTests.cs
@@ -18,7 +18,7 @@ namespace SauceDemoTests.Tests.UI.Login
 
             // Navigating to SauceDemo website.
             ReportManager.LogInfo("Navigating to SauceDemo website.");
-            _driver.Navigate().GoToUrl(_config.BaseUrl);
+            _driver!.Navigate().GoToUrl(_config.BaseUrl);
 
             // Initialize LoginPage.
             _login = new LoginPage(_driver);
@@ -29,14 +29,14 @@ namespace SauceDemoTests.Tests.UI.Login
         public void Login_WithValidCredentials(LoginTestCase testCase)
         {
             ReportManager.LogInfo("Entering username and password.");
-            _login.EnterUserName(testCase.testData.userName);
+            _login.EnterUserName(testCase.testData!.userName);
             _login.EnterPassword(testCase.testData.password);
 
             ReportManager.LogInfo("Clicking 'Login' button.");
             _login.ClickLoginBtn();
 
             ReportManager.LogInfo("Verifying dashboard is displayed.");
-            Assert.That(_driver.Url, Is.EqualTo("https://www.saucedemo.com/v1/inventory.html"));
+            Assert.That(_driver!.Url, Is.EqualTo("https://www.saucedemo.com/v1/inventory.html"));
         }
 
         // TC_Login_0002; TC_Login_0003, TC_Login_0004
@@ -44,8 +44,8 @@ namespace SauceDemoTests.Tests.UI.Login
         public void InvalidLogin_ShowsErrorMessage(LoginTestCase testCase)
         {
             ReportManager.LogInfo("Entering username and password.");
-            _login.EnterUserName(testCase.testData.userName);
-            _login.EnterPassword(testCase.testData.password);
+            _login.EnterUserName(testCase.testData!.userName);
+            _login.EnterPassword(testCase.testData!.password);
 
             ReportManager.LogInfo("Clicking 'Login' button.");
             _login.ClickLoginBtn();
@@ -74,7 +74,7 @@ namespace SauceDemoTests.Tests.UI.Login
         public void Login_PasswordFieldIsMasked(string username, string password)
         {
             // Get password field attribute.
-            var passwordField = _driver.FindElement(By.Id("password"));
+            var passwordField = _driver!.FindElement(By.Id("password"));
             var passwordType = passwordField.GetAttribute("type");
 
             ReportManager.LogInfo("Entering username and password.");

--- a/SauceDemoTests/Tests/UI/Logout/LogoutTests.cs
+++ b/SauceDemoTests/Tests/UI/Logout/LogoutTests.cs
@@ -15,11 +15,11 @@ namespace SauceDemoTests.Tests.UI.Logout
             base.SetUp();
 
             // Initialize MenuPage.
-            _menu = new MenuBarPage(_driver);
+            _menu = new MenuBarPage(_driver!);
 
             // Navigate to SauceDemo website.
             ReportManager.LogInfo("Navigating to SauceDemo website.");
-            _driver.Navigate().GoToUrl(_config.BaseUrl);
+            _driver!.Navigate().GoToUrl(_config.BaseUrl);
 
             // Log in to the system as standard user.
             ReportManager.LogInfo("Log in as standard user.");
@@ -35,7 +35,7 @@ namespace SauceDemoTests.Tests.UI.Logout
             ReportManager.LogInfo("Clicking 'Logout' link.");
             _menu.ClickSMLogoutLink();
             ReportManager.LogInfo("Verifying that user is in the login page.");
-            Assert.That(_driver.Url.Contains("index.html"), Is.True);
+            Assert.That(_driver!.Url.Contains("index.html"), Is.True);
         }
 
         // TC_Logout_0002
@@ -47,7 +47,7 @@ namespace SauceDemoTests.Tests.UI.Logout
             ReportManager.LogInfo("Clicking 'Logout' link.");
             _menu.ClickSMLogoutLink();
             ReportManager.LogInfo("Verifying that the user cannot access pages after logging out.");
-            _driver.Navigate().GoToUrl("https://www.saucedemo.com/v1/cart.html");
+            _driver!.Navigate().GoToUrl("https://www.saucedemo.com/v1/cart.html");
             ReportManager.LogInfo("SauceDemo issue: After logout, user can still access /cart.html via URL.");
             // Assert.That(_driver.Url.Contains("cart"), Is.False);
             Assert.That(_driver.Url.Contains("cart"), Is.True);

--- a/SauceDemoTests/Tests/UI/MenuBar/MenuBarTests.cs
+++ b/SauceDemoTests/Tests/UI/MenuBar/MenuBarTests.cs
@@ -16,11 +16,11 @@ namespace SauceDemoTests.Tests.UI.MenuBar
             base.SetUp();
 
             // Initialize MenuBarPage.
-            _menuBar = new MenuBarPage(_driver);
+            _menuBar = new MenuBarPage(_driver!);
 
             // Navigate to SauceDemo Website.
             ReportManager.LogInfo("Navigating to SauceDemo website.");
-            _driver.Navigate().GoToUrl(_config.BaseUrl);
+            _driver!.Navigate().GoToUrl(_config.BaseUrl);
 
             // Log in to the website.
             ReportManager.LogInfo("Log in as standard user.");
@@ -128,8 +128,8 @@ namespace SauceDemoTests.Tests.UI.MenuBar
             _menuBar.ClickSMCloseBtn();
 
             // Getting the X-axis of side menu
-            var sideMenu = _driver.FindElement(By.CssSelector(".bm-menu-wrap"));
-            string style = sideMenu.GetAttribute("style");
+            var sideMenu = _driver!.FindElement(By.CssSelector(".bm-menu-wrap"));
+            string style = sideMenu.GetAttribute("style")!;
 
             Assert.That(style.Contains("translate3d(-100%, 0px, 0px)"), "The side menu should be hidden off screen.");
         }
@@ -144,7 +144,7 @@ namespace SauceDemoTests.Tests.UI.MenuBar
             ReportManager.LogInfo("Clicking the side menu 'All Items' link.");
             _menuBar.ClickSMItemsLink();
 
-            Assert.That(_driver.Url.Contains("inventory"), Is.True);
+            Assert.That(_driver!.Url.Contains("inventory"), Is.True);
         }
 
         // No test case created to for this.
@@ -157,7 +157,7 @@ namespace SauceDemoTests.Tests.UI.MenuBar
             ReportManager.LogInfo("Clicking the side menu 'About' link.");
             _menuBar.ClickSMAboutLink();
 
-            Assert.That(_driver.Url.Contains("saucelabs"), Is.True);
+            Assert.That(_driver!.Url.Contains("saucelabs"), Is.True);
         }
 
         // No test case created to for this.
@@ -170,7 +170,7 @@ namespace SauceDemoTests.Tests.UI.MenuBar
             ReportManager.LogInfo("Clicking the side menu 'Logout' link.");
             _menuBar.ClickSMLogoutLink();
 
-            Assert.That(_driver.Url.Contains("index"), Is.True);
+            Assert.That(_driver!.Url.Contains("index"), Is.True);
         }
 
         // No test case created to for this.

--- a/SauceDemoTests/Tests/UI/Product/ProductTests.cs
+++ b/SauceDemoTests/Tests/UI/Product/ProductTests.cs
@@ -15,11 +15,11 @@ namespace SauceDemoTests.Tests.UI.Product
             base.SetUp();
 
             // Initialize ProductPage.
-            _product = new ProductPage(_driver);
+            _product = new ProductPage(_driver!);
 
             // Navigate to SauceDemo Website
             ReportManager.LogInfo("Navigating to SauceDemo website.");
-            _driver.Navigate().GoToUrl(_config.BaseUrl);
+            _driver!.Navigate().GoToUrl(_config.BaseUrl);
 
             // Log in to the website
             ReportManager.LogInfo("Log in as standard user.");
@@ -98,7 +98,7 @@ namespace SauceDemoTests.Tests.UI.Product
             _product.ClickProduct();
 
             ReportManager.LogInfo("Verify that user can see the product details page.");
-            Assert.That(_driver.Url.Contains("inventory-item.html?id"));
+            Assert.That(_driver!.Url.Contains("inventory-item.html?id"));
         }
     }
 }

--- a/SauceDemoTests/Utils/TestDataProvider.cs
+++ b/SauceDemoTests/Utils/TestDataProvider.cs
@@ -26,7 +26,7 @@ namespace SauceDemoTests.Utils
             var data = TestUtilities.TestDataReader.ReadJson<LoginTestRoot>(path);
 
             // Filter test case.
-            var filteredTestCase = data.testCases
+            var filteredTestCase = data.testCases!
                 .Where(tc => tc.testType.Equals(testType, StringComparison.OrdinalIgnoreCase))
                 .ToList();
 
@@ -46,7 +46,7 @@ namespace SauceDemoTests.Utils
             var data = TestUtilities.TestDataReader.ReadJson<CheckoutTestRoot>(path);
 
             // Filter test case.
-            var filteredTestCase = data.testCases
+            var filteredTestCase = data.testCases!
                 .Where(tc => tc.testType.Equals(testType, StringComparison.OrdinalIgnoreCase))
                 .ToList();
 

--- a/TestUtilities/ReportManager.cs
+++ b/TestUtilities/ReportManager.cs
@@ -6,9 +6,9 @@ namespace TestUtilities
 {
     public static class ReportManager
     {
-        private static ExtentReports _extent;
+        private static ExtentReports _extent = null!;
         [ThreadStatic]
-        private static ExtentTest _test;
+        private static ExtentTest _test = null!;
 
         // Create the report
         public static void CreateExtentReport(string projectName)

--- a/TestUtilities/WebDriverFactory.cs
+++ b/TestUtilities/WebDriverFactory.cs
@@ -7,7 +7,7 @@ namespace TestUtilities
     public static class WebDriverFactory
     {
         [ThreadStatic]
-        private static IWebDriver _driver;
+        private static IWebDriver? _driver;
 
         // Creating the driver base on the browser; To be used base test file.
         public static IWebDriver CreateDriver(string browser)


### PR DESCRIPTION
This pull request includes:

- Cleaned up compiler null warnings and added the abstract keyword to BaseTest classes.
- Added Profile page classes (Personal Details, Contact Details, and Profile) with corresponding locators and actions for Personal Details.
- Added constants, test data JSON files, provider, and model classes for Profile - Personal Details.
- Added test files (valid, invalid, missing) for Profile - Personal Details.